### PR TITLE
Integration specs for views and fix n+1 problems

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,7 +6,7 @@ class CommentsController < ApplicationController
     @comment.post = @post
     if @comment.save
       flash[:success] = 'New Comment created successfully'
-      redirect_to user_post_path(current_user, @post)
+      redirect_to user_posts_path(current_user, @post)
     else
       flash.now[:error] = 'An error occurred : Comment could not be created'
     end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -6,7 +6,7 @@ class LikesController < ApplicationController
     @like.post = @post
     if @like.save
       flash[:success] = 'Like Added successfully'
-      redirect_to user_post_path(current_user, @post)
+      redirect_to user_posts_path(current_user, @post)
     else
       flash.now[:error] = 'An Error occurred: Like could not be saved'
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = Post.find_by(params[:id])
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,11 +1,11 @@
 class PostsController < ApplicationController
   def index
-    @user = User.find(params[:authorId])
+    @user = User.find_by(params[:authorId])
     @posts = @user.posts
   end
 
   def show
-    @post = Post.find_by(params[:id])
+    @post = Post.find(params[:id])
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,6 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.where('id = ?', params[:id])
+    @user = User.find(params[:id])
   end
 end

--- a/app/views/partials/_post.html.erb
+++ b/app/views/partials/_post.html.erb
@@ -1,4 +1,4 @@
-<h1><%= post.Id%> </h1>
+<h1><%= post.id%> </h1>
 <h3><%= post.Title%> </h3>
 <%= post.Text %>
 <p >Comments: <span><%= post.CommentsCounter %></span>, 

--- a/app/views/partials/_post_helper.html.erb
+++ b/app/views/partials/_post_helper.html.erb
@@ -1,5 +1,5 @@
  <h2><%= post.Title%> </h2>
-    <% if post.text.length > 110 %>
+    <% if post.Text.length > 110 %>
       <%= truncate(post.text, length: 110) ... %>
     <% else %>
       <%= post.Text %>.

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,6 @@
 <% @users.each do |user| %>
 
-  <%= link_to user do %>
+  <%= link_to user, id: user.id do %>
   <%= render partial: 'partials/user', locals: {user: user} %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,10 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
 
-  root 'users#index'
   get 'users/show'
   get 'posts/index'
   get 'posts/show'
+  root 'users#index'
 
   resources :users, only: %i[index show] do
     resources :posts, only: %i[index new form create]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
-require "capybara/rspec"
+require 'capybara/rspec'
 
 begin
   ActiveRecord::Migration.maintain_test_schema!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require "capybara/rspec"
 
 begin
   ActiveRecord::Migration.maintain_test_schema!
@@ -12,6 +13,12 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+Capybara.register_driver :selenium_chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.javascript_driver = :selenium_chrome
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/requests/Integration/integration_spec.rb
+++ b/spec/requests/Integration/integration_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'User pages test index/show ', type: :feature do
+  before(:all) do
+    @first_user = User.create(Name: 'Bruk', Photo: 
+        'https://drive.google.com/file/d/1yi3fHkqGhPsmXconfRANucRZ7EpLl7dw/view',
+                              Bio: 'Software developerr')
+    @post1 = Post.create(Title: 'Rspec test 1', Text: 'rspec test for post', user: @first_user)
+    @post2 = Post.create(Title: 'Rspec test 2', Text: 'rspec test for post', user: @first_user)
+    @post3 = Post.create(Title: 'Rspec test 3', Text: 'rspec test for post', user: @first_user)
+    @post4 = Post.create(Title: 'Rspec test 4', Text: 'rspec test for post', user: @first_user)
+  end
+
+  describe 'User index page test' do
+    it 'Should show the username ' do
+      visit users_path
+      expect(page).to have_content(@first_user.Name)
+    end
+
+    it 'Should show the username of all users' do
+      visit users_path
+      expect(page).to have_content(@first_user.Name)
+    end
+
+    it 'Should show the number of posts for each user' do
+      visit users_path
+      expect(page).to have_content(@first_user.posts.count)
+    end
+
+
+    it 'Should show the Number of posts' do
+      visit users_path
+      expect(page).to have_text('Number of posts: 4')
+    end
+  end
+
+
+end

--- a/spec/requests/Integration/integration_spec.rb
+++ b/spec/requests/Integration/integration_spec.rb
@@ -27,12 +27,49 @@ RSpec.describe 'User pages test index/show ', type: :feature do
       expect(page).to have_content(@first_user.posts.count)
     end
 
-
     it 'Should show the Number of posts' do
       visit users_path
       expect(page).to have_text('Number of posts: 4')
     end
+
+    describe 'User show page test' do
+        it 'Should show the username ' do
+          visit user_path(@first_user)
+          expect(page).to have_content(@first_user.Name)
+        end
+    
+        it 'Should show the Number of posts' do
+          visit user_path(@first_user)
+          expect(page).to have_text('Number of posts: 4')
+        end
+    
+        it 'Should show the bio' do
+          visit user_path(@first_user)
+          expect(page).to have_content(@first_user.Bio)
+        end
+    
+        it 'Should show user recent 3 posts' do
+          visit user_path(@first_user)
+          expect(page).to have_content('Rspec test 2')
+          expect(page).to have_content('Rspec test 3')
+          expect(page).to have_content('Rspec test 4')
+        end
+    
+        it 'Should show button to see all posts ' do
+          visit user_path(@first_user)
+          expect(page).to have_selector(:link_or_button, 'See all posts', count: 1)
+        end
+    
+        it 'Should show button to see all posts ' do
+          visit user_path(@first_user)
+          expect(page).to have_selector(:link_or_button, 'See all posts', count: 1)
+        end
+    
+        it 'Should show redirects me to that user\'s posts page. ' do
+          visit user_path(@first_user)
+          click_on 'See all posts'
+          expect(page).to have_current_path(user_posts_path(@first_user))
+        end
+      end
   end
-
-
 end

--- a/spec/requests/Integration/integration_spec.rb
+++ b/spec/requests/Integration/integration_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe 'User pages test index/show ', type: :feature do
       expect(page).to have_text('Number of posts: 4')
     end
 
+    it 'Should redirect to user page when clicked on a user' do
+      visit users_path
+      click_on(@first_user.id)
+      expect(page).to have_current_path(user_path(@first_user))
+    end
+
     describe 'User show page test' do
       it 'Should show the username ' do
         visit user_path(@first_user)

--- a/spec/requests/Integration/integration_spec.rb
+++ b/spec/requests/Integration/integration_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'User pages test index/show ', type: :feature do
   before(:all) do
-    @first_user = User.create(Name: 'Bruk', Photo: 
+    @first_user = User.create(Name: 'Bruk', Photo:
         'https://drive.google.com/file/d/1yi3fHkqGhPsmXconfRANucRZ7EpLl7dw/view',
                               Bio: 'Software developerr')
     @post1 = Post.create(Title: 'Rspec test 1', Text: 'rspec test for post', user: @first_user)
@@ -33,43 +33,43 @@ RSpec.describe 'User pages test index/show ', type: :feature do
     end
 
     describe 'User show page test' do
-        it 'Should show the username ' do
-          visit user_path(@first_user)
-          expect(page).to have_content(@first_user.Name)
-        end
-    
-        it 'Should show the Number of posts' do
-          visit user_path(@first_user)
-          expect(page).to have_text('Number of posts: 4')
-        end
-    
-        it 'Should show the bio' do
-          visit user_path(@first_user)
-          expect(page).to have_content(@first_user.Bio)
-        end
-    
-        it 'Should show user recent 3 posts' do
-          visit user_path(@first_user)
-          expect(page).to have_content('Rspec test 2')
-          expect(page).to have_content('Rspec test 3')
-          expect(page).to have_content('Rspec test 4')
-        end
-    
-        it 'Should show button to see all posts ' do
-          visit user_path(@first_user)
-          expect(page).to have_selector(:link_or_button, 'See all posts', count: 1)
-        end
-    
-        it 'Should show button to see all posts ' do
-          visit user_path(@first_user)
-          expect(page).to have_selector(:link_or_button, 'See all posts', count: 1)
-        end
-    
-        it 'Should show redirects me to that user\'s posts page. ' do
-          visit user_path(@first_user)
-          click_on 'See all posts'
-          expect(page).to have_current_path(user_posts_path(@first_user))
-        end
+      it 'Should show the username ' do
+        visit user_path(@first_user)
+        expect(page).to have_content(@first_user.Name)
       end
+
+      it 'Should show the Number of posts' do
+        visit user_path(@first_user)
+        expect(page).to have_text('Number of posts: 4')
+      end
+
+      it 'Should show the bio' do
+        visit user_path(@first_user)
+        expect(page).to have_content(@first_user.Bio)
+      end
+
+      it 'Should show user recent 3 posts' do
+        visit user_path(@first_user)
+        expect(page).to have_content('Rspec test 2')
+        expect(page).to have_content('Rspec test 3')
+        expect(page).to have_content('Rspec test 4')
+      end
+
+      it 'Should show button to see all posts ' do
+        visit user_path(@first_user)
+        expect(page).to have_selector(:link_or_button, 'See all posts', count: 1)
+      end
+
+      it 'Should show button to see all posts ' do
+        visit user_path(@first_user)
+        expect(page).to have_selector(:link_or_button, 'See all posts', count: 1)
+      end
+
+      it 'Should show redirects me to that user\'s posts page. ' do
+        visit user_path(@first_user)
+        click_on 'See all posts'
+        expect(page).to have_current_path(user_posts_path(@first_user))
+      end
+    end
   end
 end

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -3,36 +3,34 @@ require 'rails_helper'
 RSpec.describe 'Posts', type: :request do
   describe 'GET /index' do
     before(:each) do
-      @user = User.create(Name: 'Bruk', 
-        Photo: 'https://drive.google.com/file/d/1yi3fHkqGhPsmXconfRANucRZ7EpLl7dw/view', 
-        Bio: 'Software developer')
+      @user = User.create(Name: 'Bruk',
+                          Photo: 'https://drive.google.com/file/d/1yi3fHkqGhPsmXconfRANucRZ7EpLl7dw/view',
+                          Bio: 'Software developer')
       get user_posts_path(@user)
-  end
+    end
 
-  it 'Check if response status was correct' do
-    expect(response).to have_http_status(:success)
-  end
+    it 'Check if response status was correct' do
+      expect(response).to have_http_status(:success)
+    end
 
-  it 'Check if a correct template was rendered' do
-    expect(response).to render_template(:index)
-  end
+    it 'Check if a correct template was rendered' do
+      expect(response).to render_template(:index)
+    end
 
-  describe 'GET /show' do
-    before(:each) do
-      @user = User.create(Name: 'Jo', Photo: 'sodome/png', Bio: 'web Developer from Ethiopia')
-      @post = Post.create(user: @user, Title: 'test', Text: 'A test post')
-      get user_posts_path(@user, @post)
+    describe 'GET /show' do
+      before(:each) do
+        @user = User.create(Name: 'Jo', Photo: 'sodome/png', Bio: 'web Developer from Ethiopia')
+        @post = Post.create(user: @user, Title: 'test', Text: 'A test post')
+        get user_posts_path(@user, @post)
 
-      it 'Check if response status was correct' do
-        expect(response).to have_http_status(:success)
-      end
+        it 'Check if response status was correct' do
+          expect(response).to have_http_status(:success)
+        end
 
-      it 'Check if a correct template was rendered' do
-        expect(response).to_not render_template(:show)
+        it 'Check if a correct template was rendered' do
+          expect(response).to_not render_template(:show)
+        end
       end
     end
-  end
-  
-
   end
 end

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe 'Posts', type: :request do
       get user_posts_path(@user)
   end
 
+  it 'Check if response status was correct' do
+    expect(response).to have_http_status(:success)
+  end
+
+  it 'Check if a correct template was rendered' do
+    expect(response).to render_template(:index)
+  end
+
   describe 'GET /show' do
     before(:each) do
       @user = User.create(Name: 'Jo', Photo: 'sodome/png', Bio: 'web Developer from Ethiopia')

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -2,46 +2,29 @@ require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
   describe 'GET /index' do
-    it 'Return http success' do
-      get '/posts/index'
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  it 'Should render the index template' do
-    get '/posts/index'
-    expect(response).to render_template(:index)
-  end
-
-  it 'does not render a different template' do
-    get '/posts/index'
-    expect(response).to_not render_template(:show)
-  end
-
-  it 'Should include the correct placeholder' do
-    get '/posts/index'
-    expect(response.body).to include('Here is a list of posts')
+    before(:each) do
+      @user = User.create(Name: 'Bruk', 
+        Photo: 'https://drive.google.com/file/d/1yi3fHkqGhPsmXconfRANucRZ7EpLl7dw/view', 
+        Bio: 'Software developer')
+      get user_posts_path(@user)
   end
 
   describe 'GET /show' do
-    it 'Return http success' do
-      get '/posts/show'
-      expect(response).to have_http_status(:success)
+    before(:each) do
+      @user = User.create(Name: 'Jo', Photo: 'sodome/png', Bio: 'web Developer from Ethiopia')
+      @post = Post.create(user: @user, Title: 'test', Text: 'A test post')
+      get user_posts_path(@user, @post)
+
+      it 'Check if response status was correct' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'Check if a correct template was rendered' do
+        expect(response).to_not render_template(:show)
+      end
     end
   end
+  
 
-  it 'Should render the index template' do
-    get '/posts/show'
-    expect(response).to render_template(:show)
-  end
-
-  it 'does not render a different template' do
-    get '/posts/show'
-    expect(response).to_not render_template(:index)
-  end
-
-  it 'Should include the correct placeholder' do
-    get '/posts/show'
-    expect(response.body).to include('Here is a list of single post.')
   end
 end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe 'Users', type: :request do
     
     it 'Check if response status was correct' do
       expect(response).to have_http_status(:success)
-    end
-   
+    end 
     
   end
 end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -14,15 +14,14 @@ RSpec.describe 'Users', type: :request do
 
   describe 'GET /show' do
     before(:each) do
-      @user = User.create(Name: 'Bruk', Photo: 
+      @user = User.create(Name: 'Bruk', Photo:
         'https://drive.google.com/file/d/1yi3fHkqGhPsmXconfRANucRZ7EpLl7dw/view',
                           Bio: 'test for User')
       get user_path(@user)
     end
-    
+
     it 'Check if response status was correct' do
       expect(response).to have_http_status(:success)
-    end 
-    
+    end
   end
 end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,47 +1,29 @@
 require 'rails_helper'
-
 RSpec.describe 'Users', type: :request do
   describe 'GET /index' do
-    it 'Return http success' do
-      get '/users/index'
+    before(:each) do
+      get users_path
+    end
+    it 'Check if response status was correct' do
       expect(response).to have_http_status(:success)
     end
-  end
-
-  it 'Should render the index template' do
-    get '/users/index'
-    expect(response).to render_template(:index)
-  end
-
-  it 'does not render a different template' do
-    get '/users/index'
-    expect(response).to_not render_template(:show)
-  end
-
-  it 'Should include the correct placeholder' do
-    get '/users/index'
-    expect(response.body).to include(' Here is a list of Users.')
+    it 'Check if a correct template was rendered' do
+      expect(response).to render_template(:index)
+    end
   end
 
   describe 'GET /show' do
-    it 'Return http success' do
-      get '/users/show'
+    before(:each) do
+      @user = User.create(Name: 'Bruk', Photo: 
+        'https://drive.google.com/file/d/1yi3fHkqGhPsmXconfRANucRZ7EpLl7dw/view',
+                          Bio: 'test for User')
+      get user_path(@user)
+    end
+    
+    it 'Check if response status was correct' do
       expect(response).to have_http_status(:success)
     end
-  end
-
-  it 'Should render the index template' do
-    get '/users/show'
-    expect(response).to render_template(:show)
-  end
-
-  it 'does not render a different template' do
-    get '/users/show'
-    expect(response).to_not render_template(:index)
-  end
-
-  it 'Should include the correct placeholder' do
-    get '/users/show'
-    expect(response.body).to include(' Here is a list of Single User. ')
+   
+    
   end
 end


### PR DESCRIPTION
In this PR:-
- Used Capybara to write integration tests for each view project.
- User index page:
    I can see the username of all other users.
    I can see the profile picture for each user.
    I can see the number of posts each user has written.
    When I click on a user, I am redirected to that user's show page.

- user show page:
   I can see the user's profile picture.
   I can see the user's username.
   I can see the number of posts the user has written.
   I can see the user's bio.
   I can see the user's first 3 posts.
   I can see a button that lets me view all of a user's posts.
   When I click a user's post, it redirects me to that post's show page.
   When I click to see all posts, it redirects me to the user's post's index page.

- User post index page:
   I can see the user's profile picture.
   I can see the user's username.
   I can see the number of posts the user has written.
   I can see a post's title.
   I can see some of the post's body.
   I can see the first comments on a post.
   I can see how many comments a post has.
   I can see how many likes a post has.
   I can see a section for pagination if there are more posts than fit on the view.
   When I click on a post, it redirects me to that post's show page.

- Post show page:
  I can see the post's title.
  I can see who wrote the post.
  I can see how many comments it has.
  I can see how many likes it has.
  I can see the post body.
  I can see the username of each commentor.
  I can see the comment each commentor left.

